### PR TITLE
use clock to pick values; better input handling

### DIFF
--- a/src/TimeInput.spec.jsx
+++ b/src/TimeInput.spec.jsx
@@ -105,9 +105,9 @@ describe('TimeInput', () => {
     const customInputs = component.find('input[type="number"]');
 
     expect(nativeInput.prop('value')).toBe(date);
-    expect(customInputs.at(0).prop('value')).toBe(10);
-    expect(customInputs.at(1).prop('value')).toBe(17);
-    expect(customInputs.at(2).prop('value')).toBe(0);
+    expect(customInputs.at(0).prop('value')).toBe('10');
+    expect(customInputs.at(1).prop('value')).toBe('17');
+    expect(customInputs.at(2).prop('value')).toBe('00');
   });
 
   itIfFullICU('shows a given time in all inputs correctly (24-hour format)', () => {
@@ -169,6 +169,22 @@ describe('TimeInput', () => {
     expect(customInputs.at(0).prop('value')).toBeFalsy();
     expect(customInputs.at(1).prop('value')).toBeFalsy();
     expect(customInputs.at(2).prop('value')).toBeFalsy();
+  });
+
+  it('clears any entered values if the clock is opened', () => {
+    const component = mount(
+      <TimeInput
+        {...defaultProps}
+        isClockOpen={false}
+        maxDetail="second"
+      />
+    );
+
+    const customInputs = component.find('input[type="number"]');
+    customInputs.at(0).getDOMNode().value = '10';
+    expect(customInputs.at(0).getDOMNode().value).toBe('10');
+    component.setProps({ isClockOpen: true });
+    expect(customInputs.at(0).getDOMNode().value).toBeFalsy();
   });
 
   it('renders custom inputs in a proper order (12-hour format)', () => {
@@ -626,7 +642,7 @@ describe('TimeInput', () => {
 
   it('triggers onChange correctly when changed custom input', () => {
     const onChange = jest.fn();
-    const date = '22:17:00';
+    const date = '10:17:00';
 
     const component = mount(
       <TimeInput
@@ -639,11 +655,11 @@ describe('TimeInput', () => {
 
     const customInputs = component.find('input[type="number"]');
 
-    customInputs.at(0).getDOMNode().value = '20';
+    customInputs.at(0).getDOMNode().value = '11';
     customInputs.at(0).simulate('change');
 
     expect(onChange).toHaveBeenCalled();
-    expect(onChange).toHaveBeenCalledWith('20:17:00', false);
+    expect(onChange).toHaveBeenCalledWith('11:17:00', false);
   });
 
   it('triggers onChange correctly when cleared custom inputs', () => {

--- a/src/TimeInput/Hour12Input.jsx
+++ b/src/TimeInput/Hour12Input.jsx
@@ -15,6 +15,7 @@ export default function Hour12Input({
   hour,
   maxTime,
   minTime,
+  onChange,
   value,
   ...otherProps
 }) {
@@ -52,6 +53,13 @@ export default function Hour12Input({
       min={minHour}
       name="hour12"
       nameForClass="hour"
+      onChange={(event) => {
+        if (event.target.value === '0') {
+          event.preventDefault();
+        } else if (onChange) {
+          onChange(event);
+        }
+      }}
       value={value12}
       {...otherProps}
     />

--- a/src/TimeInput/Hour12Input.spec.jsx
+++ b/src/TimeInput/Hour12Input.spec.jsx
@@ -90,7 +90,7 @@ describe('Hour12Input', () => {
 
     const input = component.find('input');
 
-    expect(input.prop('value')).toBe(value);
+    expect(input.prop('value')).toBe(String(value));
   });
 
   it('displays given value properly (pm)', () => {
@@ -105,7 +105,7 @@ describe('Hour12Input', () => {
 
     const input = component.find('input');
 
-    expect(input.prop('value')).toBe(value - 12);
+    expect(input.prop('value')).toBe(String(value - 12));
   });
 
   it('does not disable input by default', () => {

--- a/src/TimeInput/Hour24Input.spec.jsx
+++ b/src/TimeInput/Hour24Input.spec.jsx
@@ -89,7 +89,7 @@ describe('Hour24Input', () => {
 
     const input = component.find('input');
 
-    expect(input.prop('value')).toBe(value);
+    expect(input.prop('value')).toBe(String(value));
   });
 
   it('does not disable input by default', () => {

--- a/src/TimeInput/MinuteInput.spec.jsx
+++ b/src/TimeInput/MinuteInput.spec.jsx
@@ -61,8 +61,7 @@ describe('MinuteInput', () => {
 
     const input = component.find('input');
 
-    expect(component.text()).toContain('0');
-    expect(input.prop('className')).toContain(`${defaultProps.className}__input--hasLeadingZero`);
+    expect(input.prop('value')).toBe('09');
   });
 
   it('does not render "0" if minute is >=10', () => {
@@ -117,7 +116,7 @@ describe('MinuteInput', () => {
 
     const input = component.find('input');
 
-    expect(input.prop('value')).toBe(value);
+    expect(input.prop('value')).toBe(String(value));
   });
 
   it('does not disable input by default', () => {
@@ -225,7 +224,7 @@ describe('MinuteInput', () => {
 
     const input = component.find('input');
 
-    expect(input.prop('max')).toBe(59);
+    expect(input.prop('max')).toBe(`${59}0`);
   });
 
   it('has max = 59 given maxTime in a future hour', () => {
@@ -239,7 +238,7 @@ describe('MinuteInput', () => {
 
     const input = component.find('input');
 
-    expect(input.prop('max')).toBe(59);
+    expect(input.prop('max')).toBe(`${59}0`);
   });
 
   it('has max = (minute in maxHour) given maxTime in a current hour', () => {
@@ -253,6 +252,6 @@ describe('MinuteInput', () => {
 
     const input = component.find('input');
 
-    expect(input.prop('max')).toBe(40);
+    expect(input.prop('max')).toBe(`${40}0`);
   });
 });

--- a/src/TimeInput/SecondInput.spec.jsx
+++ b/src/TimeInput/SecondInput.spec.jsx
@@ -61,8 +61,7 @@ describe('SecondInput', () => {
 
     const input = component.find('input');
 
-    expect(component.text()).toContain('0');
-    expect(input.prop('className')).toContain(`${defaultProps.className}__input--hasLeadingZero`);
+    expect(input.prop('value')).toBe('09');
   });
 
   it('does not render "0" if second is >=10', () => {
@@ -117,7 +116,7 @@ describe('SecondInput', () => {
 
     const input = component.find('input');
 
-    expect(input.prop('value')).toBe(value);
+    expect(input.prop('value')).toBe(String(value));
   });
 
   it('does not disable input by default', () => {
@@ -227,7 +226,7 @@ describe('SecondInput', () => {
 
     const input = component.find('input');
 
-    expect(input.prop('max')).toBe(59);
+    expect(input.prop('max')).toBe(`${59}0`);
   });
 
   it('has max = 59 given maxTime in a future minute', () => {
@@ -242,7 +241,7 @@ describe('SecondInput', () => {
 
     const input = component.find('input');
 
-    expect(input.prop('max')).toBe(59);
+    expect(input.prop('max')).toBe(`${59}0`);
   });
 
   it('has max = (second in maxHour) given maxTime in a current minute', () => {
@@ -257,6 +256,6 @@ describe('SecondInput', () => {
 
     const input = component.find('input');
 
-    expect(input.prop('max')).toBe(15);
+    expect(input.prop('max')).toBe(`${15}0`);
   });
 });

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -3,9 +3,6 @@ import PropTypes from 'prop-types';
 import { polyfill } from 'react-lifecycles-compat';
 import makeEventProps from 'make-event-props';
 import mergeClassNames from 'merge-class-names';
-import Fit from 'react-fit';
-
-import Clock from 'react-clock/dist/entry.nostyle';
 
 import TimeInput from './TimeInput';
 
@@ -81,7 +78,15 @@ export default class TimePicker extends PureComponent {
       return;
     }
 
-    this.openClock();
+    if (event.target.name) {
+      this.setState({ focusedElement: event.target.name });
+
+      if (event.target.name === 'amPm') {
+        this.closeClock();
+      } else {
+        this.openClock();
+      }
+    }
   }
 
   openClock = () => {
@@ -127,9 +132,7 @@ export default class TimePicker extends PureComponent {
       format,
       hourAriaLabel,
       hourPlaceholder,
-      isOpen,
       locale,
-      maxDetail,
       maxTime,
       minTime,
       minuteAriaLabel,
@@ -139,7 +142,16 @@ export default class TimePicker extends PureComponent {
       required,
       secondAriaLabel,
       secondPlaceholder,
+    } = this.props;
+    const { focusedElement, isOpen } = this.state;
+
+    const {
+      clockClassName,
+      className: timePickerClassName, // Unused, here to exclude it from clockProps
+      maxDetail,
+      onChange,
       value,
+      ...clockProps
     } = this.props;
 
     const [valueFrom] = [].concat(value);
@@ -165,7 +177,11 @@ export default class TimePicker extends PureComponent {
           {...placeholderProps}
           autoFocus={autoFocus}
           className={`${baseClassName}__inputGroup`}
+          clockClassName={clockClassName}
+          clockProps={clockProps}
+          disableClock={disableClock}
           disabled={disabled}
+          focusedElement={focusedElement}
           format={format}
           isClockOpen={isOpen}
           locale={locale}
@@ -195,7 +211,6 @@ export default class TimePicker extends PureComponent {
             aria-label={clockAriaLabel}
             className={`${baseClassName}__clock-button ${baseClassName}__button`}
             disabled={disabled}
-            onBlur={this.resetValue}
             onClick={this.toggleClock}
             onFocus={this.stopPropagation}
             type="button"
@@ -204,43 +219,6 @@ export default class TimePicker extends PureComponent {
           </button>
         )}
       </div>
-    );
-  }
-
-  renderClock() {
-    const { disableClock } = this.props;
-    const { isOpen } = this.state;
-
-    if (isOpen === null || disableClock) {
-      return null;
-    }
-
-    const {
-      clockClassName,
-      className: timePickerClassName, // Unused, here to exclude it from clockProps
-      maxDetail,
-      onChange,
-      value,
-      ...clockProps
-    } = this.props;
-
-    const className = `${baseClassName}__clock`;
-    const [valueFrom] = [].concat(value);
-
-    const maxDetailIndex = allViews.indexOf(maxDetail);
-
-    return (
-      <Fit>
-        <div className={mergeClassNames(className, `${className}--${isOpen ? 'open' : 'closed'}`)}>
-          <Clock
-            className={clockClassName}
-            renderMinuteHand={maxDetailIndex > 0}
-            renderSecondHand={maxDetailIndex > 1}
-            value={valueFrom}
-            {...clockProps}
-          />
-        </div>
-      </Fit>
     );
   }
 
@@ -267,7 +245,6 @@ export default class TimePicker extends PureComponent {
         }}
       >
         {this.renderInputs()}
-        {this.renderClock()}
       </div>
     );
   }

--- a/src/TimePicker.less
+++ b/src/TimePicker.less
@@ -28,6 +28,7 @@
     flex-grow: 1;
     padding: 0 2px;
     box-sizing: content-box;
+    position: relative;
 
     &__divider {
       padding: 1px 0;

--- a/src/TimePicker.spec.jsx
+++ b/src/TimePicker.spec.jsx
@@ -335,7 +335,7 @@ describe('TimePicker', () => {
     expect(component.state('isOpen')).toBe(true);
   });
 
-  it('clears any entered values if the clock is opened', () => {
+  it('keeps any entered values if the clock is opened', () => {
     const component = mount(
       <TimePicker
         isOpen={false}
@@ -350,7 +350,23 @@ describe('TimePicker', () => {
     expect(hourInput.getDOMNode().value).toBe('10');
     component.setProps({ isOpen: true });
     component.update();
-    expect(hourInput.getDOMNode().value).toBeFalsy();
+    expect(hourInput.getDOMNode().value).toBe('10');
+  });
+
+  it('does not clear any entered values if user re-focuses the input', () => {
+    const component = mount(
+      <TimePicker />
+    );
+
+    const customInputs = component.find('input[type="number"]');
+    const hourInput = customInputs.at(0);
+    hourInput.getDOMNode().value = '10';
+    hourInput.simulate('change');
+
+    expect(hourInput.getDOMNode().value).toBe('10');
+    hourInput.simulate('focus');
+    component.update();
+    expect(hourInput.getDOMNode().value).toBe('10');
   });
 
   it('closes Clock when calling internal onChange', () => {

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -4,6 +4,7 @@ const isValidNumber = a => typeof a === 'number' && !isNaN(a);
 
 export const min = (...args) => Math.min(...args.filter(isValidNumber));
 export const max = (...args) => Math.max(...args.filter(isValidNumber));
+export const padStart = num => `0${num}`.slice(-2);
 
 const nines = ['9', '٩'];
 const ninesRegExp = new RegExp(`[${nines.join('')}]`);


### PR DESCRIPTION
- move Clock component down into TimeInput so we can let users click on it to select values
- extract padStart to a util (probably want to get it from date-utils)
- remove clock open changing clearing the value
- do nothing if user types a 0 in the hour12 input so it doesn't automatically turn into a 12
- expect all inputs to work with string values to better handle leading zeros
- add an extra 0 to the max of inputs that show leading zeros
- this allows typing when the value is 00
- we also trim any extra values off the front if there's more than 3 numbers in the value
- prevent inputting values beyond the max

depends on https://github.com/EverFi/react-clock/pull/1